### PR TITLE
Update .NET SDK examples to use `await` instead of `.Result`

### DIFF
--- a/NeverBounceApi/Program.cs
+++ b/NeverBounceApi/Program.cs
@@ -32,7 +32,9 @@ namespace NeverBounceSdkExamples
         private static void Main(string[] args)
         {
             var sdk = new NeverBounceSdk("api_key");
-
+            
+            // https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/await
+            
             var response = AccountEndpoint.Info(sdk).Result;
             //var response = POEEndpoints.Confirm(sdk).Result;
             //var response = SingleEndpoints.Check(sdk).Result;

--- a/NeverBounceApi/Program.cs
+++ b/NeverBounceApi/Program.cs
@@ -21,7 +21,6 @@
 // THE SOFTWARE.
 
 using System;
-using System.Threading.Tasks;
 using NeverBounce;
 using NeverBounceSdkExamples.Requests;
 

--- a/NeverBounceApi/Program.cs
+++ b/NeverBounceApi/Program.cs
@@ -21,6 +21,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Threading.Tasks;
 using NeverBounce;
 using NeverBounceSdkExamples.Requests;
 
@@ -32,18 +33,18 @@ namespace NeverBounceSdkExamples
         {
             var sdk = new NeverBounceSdk("api_key");
 
-            var response = AccountEndpoint.Info(sdk);
-            //var response = POEEndpoints.Confirm(sdk);
-            //var response = SingleEndpoints.Check(sdk);
-            //var response = JobsEndpoint.Search(sdk);
-            //var response = JobsEndpoint.CreateSuppliedData(sdk);
-            //var response = JobsEndpoint.CreateRemoteUrl(sdk);
-            //var response = JobsEndpoint.Parse(sdk);
-            //var response = JobsEndpoint.Start(sdk);
-            //var response = JobsEndpoint.Status(sdk);
-            //var response = JobsEndpoint.Results(sdk);
-            //var response = JobsEndpoint.Download(sdk);
-            //var response = JobsEndpoint.Delete(sdk);
+            var response = AccountEndpoint.Info(sdk).Result;
+            //var response = POEEndpoints.Confirm(sdk).Result;
+            //var response = SingleEndpoints.Check(sdk).Result;
+            //var response = JobsEndpoint.Search(sdk).Result;
+            //var response = JobsEndpoint.CreateSuppliedData(sdk).Result;
+            //var response = JobsEndpoint.CreateRemoteUrl(sdk).Result;
+            //var response = JobsEndpoint.Parse(sdk).Result;
+            //var response = JobsEndpoint.Start(sdk).Result;
+            //var response = JobsEndpoint.Status(sdk).Result;
+            //var response = JobsEndpoint.Results(sdk).Result;
+            //var response = JobsEndpoint.Download(sdk).Result;
+            //var response = JobsEndpoint.Delete(sdk).Result;
 
             var_dump(response);
             Console.ReadLine();

--- a/NeverBounceApi/Requests/AccountEndpoint.cs
+++ b/NeverBounceApi/Requests/AccountEndpoint.cs
@@ -22,14 +22,15 @@
 
 using NeverBounce;
 using NeverBounce.Models;
+using System.Threading.Tasks;
 
 namespace NeverBounceSdkExamples.Requests
 {
     public class AccountEndpoint
     {
-        public static AccountInfoResponseModel Info(NeverBounceSdk sdk)
+        public static async Task<AccountInfoResponseModel> Info(NeverBounceSdk sdk)
         {
-            return sdk.Account.Info().Result;
+            return await sdk.Account.Info();
         }
     }
 }

--- a/NeverBounceApi/Requests/JobsEndpoint.cs
+++ b/NeverBounceApi/Requests/JobsEndpoint.cs
@@ -21,6 +21,7 @@
 // THE SOFTWARE.
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using NeverBounce;
 using NeverBounce.Models;
 
@@ -28,14 +29,14 @@ namespace NeverBounceSdkExamples.Requests
 {
     public class JobsEndpoint
     {
-        public static JobSearchResponseModel Search(NeverBounceSdk sdk)
+        public static async Task<JobSearchResponseModel> Search(NeverBounceSdk sdk)
         {
             var model = new JobSearchRequestModel();
             model.job_id = 288025;
-            return sdk.Jobs.Search(model).Result;
+            return await sdk.Jobs.Search(model);
         }
 
-        public static JobCreateResponseModel CreateSuppliedData(NeverBounceSdk sdk)
+        public static async Task<JobCreateResponseModel> CreateSuppliedData(NeverBounceSdk sdk)
         {
             var model = new JobCreateSuppliedDataRequestModel();
             model.filename = "Created From dotNET.csv";
@@ -45,59 +46,59 @@ namespace NeverBounceSdkExamples.Requests
             data.Add(new {id = "3", email = "support@neverbounce.com", name = "Fred McValid"});
             data.Add(new {id = "4", email = "invalid@neverbounce.com", name = "Bob McInvalid"});
             model.input = data;
-            return sdk.Jobs.CreateFromSuppliedData(model).Result;
+            return await sdk.Jobs.CreateFromSuppliedData(model);
         }
 
-        public static JobCreateResponseModel CreateRemoteUrl(NeverBounceSdk sdk)
+        public static async Task<JobCreateResponseModel> CreateRemoteUrl(NeverBounceSdk sdk)
         {
             var model = new JobCreateRemoteUrlRequestModel();
             model.filename = "Created From dotNET.csv";
             model.auto_parse = true;
             model.auto_start = false;
             model.input = "https://example.com/file.csv";
-            return sdk.Jobs.CreateFromRemoteUrl(model).Result;
+            return await sdk.Jobs.CreateFromRemoteUrl(model);
         }
 
-        public static JobParseResponseModel Parse(NeverBounceSdk sdk)
+        public static async Task<JobParseResponseModel> Parse(NeverBounceSdk sdk)
         {
             var model = new JobParseRequestModel();
             model.job_id = 290561;
-            return sdk.Jobs.Parse(model).Result;
+            return await sdk.Jobs.Parse(model);
         }
 
-        public static JobStartResponseModel Start(NeverBounceSdk sdk)
+        public static async Task<JobStartResponseModel> Start(NeverBounceSdk sdk)
         {
             var model = new JobStartRequestModel();
             model.job_id = 290561;
-            return sdk.Jobs.Start(model).Result;
+            return await sdk.Jobs.Start(model);
         }
 
-        public static JobStatusResponseModel Status(NeverBounceSdk sdk)
+        public static async Task<JobStatusResponseModel> Status(NeverBounceSdk sdk)
         {
             var model = new JobStatusRequestModel();
             model.job_id = 290561;
-            return sdk.Jobs.Status(model).Result;
+            return await sdk.Jobs.Status(model);
         }
 
-        public static JobResultsResponseModel Results(NeverBounceSdk sdk)
+        public static async Task<JobResultsResponseModel> Results(NeverBounceSdk sdk)
         {
             var model = new JobResultsRequestModel();
             model.job_id = 290561;
-            return sdk.Jobs.Results(model).Result;
+            return await sdk.Jobs.Results(model);
         }
 
-        public static string Download(NeverBounceSdk sdk)
+        public static async Task<string> Download(NeverBounceSdk sdk)
         {
             var model = new JobDownloadRequestModel();
             model.job_id = 290561;
-            return sdk.Jobs.Download(model).Result;
+            return await sdk.Jobs.Download(model);
         }
 
-        public static JobDeleteResponseModel Delete(NeverBounceSdk sdk)
+        public static async Task<JobDeleteResponseModel> Delete(NeverBounceSdk sdk)
         {
             var model = new JobDeleteRequestModel();
             model.job_id = 290561;
-            return sdk.Jobs.Delete(model).Result;
+            return await sdk.Jobs.Delete(model);
         }
     }
 }

--- a/NeverBounceApi/Requests/POEEndpoints.cs
+++ b/NeverBounceApi/Requests/POEEndpoints.cs
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System.Threading.Tasks;
 using NeverBounce;
 using NeverBounce.Models;
 
@@ -27,14 +28,14 @@ namespace NeverBounceSdkExamples.Requests
 {
     public class POEEndpoints
     {
-        public static POEConfirmResponseModel Confirm(NeverBounceSdk sdk)
+        public static async Task<POEConfirmResponseModel> Confirm(NeverBounceSdk sdk)
         {
             var model = new POEConfirmRequestModel();
             model.email = "support@neverbounce.com";
             model.confirmation_token = "e3173fdbbdce6bad26522dae792911f2";
             model.transaction_id = "NBPOE-TXN-5942940c09669";
             model.result = "valid";
-            return sdk.POE.Confirm(model).Result;
+            return await sdk.POE.Confirm(model);
         }
     }
 }

--- a/NeverBounceApi/Requests/SingleEndpoints.cs
+++ b/NeverBounceApi/Requests/SingleEndpoints.cs
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System.Threading.Tasks;
 using NeverBounce;
 using NeverBounce.Models;
 
@@ -27,13 +28,13 @@ namespace NeverBounceSdkExamples.Requests
 {
     public class SingleEndpoints
     {
-        public static SingleResponseModel Check(NeverBounceSdk sdk)
+        public static async Task<SingleResponseModel> Check(NeverBounceSdk sdk)
         {
             var model = new SingleRequestModel();
             model.email = "support@neverbounce.com";
             model.credits_info = true;
             model.address_info = true;
-            return sdk.Single.Check(model).Result;
+            return await sdk.Single.Check(model);
         }
     }
 }

--- a/NeverBounceSDK/NeverBounceSDK.csproj
+++ b/NeverBounceSDK/NeverBounceSDK.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>NeverBounce</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <PackageVersion>4.0.3</PackageVersion>
+    <PackageVersion>4.0.4</PackageVersion>
     <Authors>Mike Mollick</Authors>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Owners>NeverBounce</Owners>

--- a/NeverBounceSDK/Properties/AssemblyInfo.cs
+++ b/NeverBounceSDK/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("4.0.0.0")]
-[assembly: AssemblyFileVersion("4.0.3.0")]
-[assembly: AssemblyInformationalVersion("4.0.3")]
+[assembly: AssemblyFileVersion("4.0.4.0")]
+[assembly: AssemblyInformationalVersion("4.0.4")]


### PR DESCRIPTION
Our examples currently look like this:

`sdk.Single.Check(model).Result`

However, this method of dealing with Async method in .NET is prone to deadlocks when used in UI threads. We frequently have users reaching out wondering why they're application is hanging and they never receive a response. The solution is to use the following instead:

`await sdk.Single.Check(model)`