### PR TITLE
Fix to JobStatusResponseModel

### DIFF
--- a/NeverBounceSDK/Models/JobModels.cs
+++ b/NeverBounceSDK/Models/JobModels.cs
@@ -143,7 +143,7 @@ namespace NeverBounce.Models
         public JobsTotals total { get; set; }
         public float bounce_estimate { get; set; }
         public float percent_complete { get; set; }
-        public float failure_reason { get; set; }
+        public string failure_reason { get; set; }
     }
 
     public class JobResultsRequestModel : RequestModel


### PR DESCRIPTION
'failure_reason' is returning from the API as a string message, not a float value. My earlier pull request only fixed the null issue, but it is actually a string value that is being return when there is an actual failure.